### PR TITLE
clair integrate with dockyard

### DIFF
--- a/clair/clair_test.go
+++ b/clair/clair_test.go
@@ -17,23 +17,28 @@ func DemoConfig() ClairConfig {
 }
 
 func Test_ClairService(t *testing.T) {
-	if err := ClairServiceInit(); err != nil {
+	if err := InitClair(); err != nil {
 		t.Log("Clair service init failed!")
 		return
 	} else {
 		fmt.Println("Success in init clair service")
 	}
-	id := "123"
-	parentID := ""
+	var h History
+	h.ID = "123"
+	h.Parent = ""
 	// Assume we have this layer file in the current directoy
-	Path := "123.tar"
+	h.localPath = "123.tar"
 
-	if vulns, err := ClairGetVulns(id, parentID, Path); err != nil {
+	if err := PutLayer(h); err != nil {
+		fmt.Println("Cannot put layer")
+		return
+	}
+	if vulns, err := GetVulns(h.ID); err != nil {
 		for index := 0; index < len(vulns); index++ {
 			fmt.Println(*vulns[index])
 		}
 	} else {
 		fmt.Println("No vul risk!")
 	}
-	ClairServiceStop()
+	StopClair()
 }

--- a/handler/manifests.go
+++ b/handler/manifests.go
@@ -8,6 +8,7 @@ import (
 	"github.com/astaxie/beego/logs"
 	"gopkg.in/macaron.v1"
 
+	"github.com/containerops/dockyard/clair"
 	"github.com/containerops/dockyard/models"
 	"github.com/containerops/dockyard/module"
 	"github.com/containerops/wrench/setting"
@@ -53,6 +54,10 @@ func PutManifestsV2Handler(ctx *macaron.Context, log *logs.BeeLogger) (int, []by
 
 		result, _ := json.Marshal(map[string]string{"message": "Get manifest digest failed"})
 		return http.StatusBadRequest, result
+	}
+
+	if err := clair.Put(ManifestCtx, "Docker", "V2"); err != nil {
+		log.Error("[REGISTRY API V2] Failed to scan Manifest Error: %v", err)
 	}
 
 	random := fmt.Sprintf("%s://%s/v2/%s/%s/manifests/%s",

--- a/web/web.go
+++ b/web/web.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/macaron.v1"
 
 	"github.com/containerops/dockyard/backend"
+	"github.com/containerops/dockyard/clair"
 	"github.com/containerops/dockyard/middleware"
 	"github.com/containerops/dockyard/oss"
 	"github.com/containerops/dockyard/router"
@@ -21,6 +22,10 @@ func SetDockyardMacaron(m *macaron.Macaron) {
 	}
 
 	if err := backend.InitBackend(); err != nil {
+		fmt.Printf("Init backend error %s", err.Error())
+	}
+
+	if err := clair.InitClair(); err != nil {
 		fmt.Printf("Init backend error %s", err.Error())
 	}
 


### PR DESCRIPTION
Signed-off-by: liangchenye <liangchenye@huawei.com>

Works in my test: add put/get interface to scan docker v2 image.

TODO:
1. we need to add a specific clair upstream version to 'Godeps'
2. take to @ChengTiesheng about the integrate with his work.

And there will be other patches to support:
1. v1 image
2. aci image