### PR TITLE
add rkt test

### DIFF
--- a/test/rkt/README.MD
+++ b/test/rkt/README.MD
@@ -1,0 +1,69 @@
+#How to test 'rkt'
+- [Setup enviornment](#install-the-required-commands)
+- [Create testing image](#build-user-image)
+- [Modify testconf and Run test](#modify-testsuitconf)
+
+###Install the required commands
+```
+#Install rkt
+wget https://github.com/coreos/rkt/releases/download/v0.15.0/rkt-v0.15.0.tar.gz
+tar -zxvf rkt-v0.15.0.tar.gz
+cd rkt-v0.15.0
+cp rkt /etc/local/bin -f
+
+#Install actools
+wget https://github.com/appc/spec/releases/download/v0.7.4/appc-v0.7.4.tar.gz
+tar -zxvf appc-v0.7.4.tar.gz
+cd appc-v0.7.4
+cp actools /etc/local/bin -f
+
+#Install acpush
+cd github.com
+git clone https://github.com/dgonyeo/acpush.git
+cp acpush appc/acpush -r
+cd appc/acpush
+go build
+cp acpush /usr/local/bin/ -f
+
+#Install and setup dockyard
+cd $GOPARH/src/github.com
+git clone github.com/containerops/dockyard
+cd dockyard
+make
+vim conf/runtime.conf
+....
+mkdir -p data/acis/pubkeys/user0/etcd
+mkdir -p data/acis/pubkeys/user1/etcd
+./dockyard web --address 0.0.0.0 --port 443
+```
+
+###Build user image
+```
+cd /home/workspace/aci/acitest/
+cd user0  #user0 for example
+cat etcd-v2.2.0/manifest
+actool build etcd-v2.2.0-linux-amd64/ etcd-v2.2.0-linux-amd64.aci
+actool -debug validate etcd-v2.2.0-linux-amd64.aci
+cat gpg-batch
+gpg --batch --gen-key gpg-batch
+gpg --no-default-keyring --armor --secret-keyring ./rkt.sec --keyring ./rkt.pub --output etcd-v2.2.0-linux-amd64.aci.asc  --detach-sig etcd-v2.2.0-linux-amd64.aci
+gpg --no-default-keyring --armor --secret-keyring ./rkt.sec --keyring ./rkt.pub --export user0@xxx.com > pubkeys.gpg
+cp pubkeys.gpg /home/workspace/gopath/src/github.com/containerops/dockyard/data/acis/pubkeys/user0/etcd/ -f
+```
+
+###Modify testsuit.conf
+```
+domains  = containerops.me
+username = user0
+pushcmd  = acpush
+fetchcmd = rkt
+image    = /home/workspace/aci/acitest/etcd-v2.2.0-linux-amd64.aci
+```
+
+And now start to test
+```
+cd test/rkt
+go test
+```
+
+

--- a/test/rkt/config_test.go
+++ b/test/rkt/config_test.go
@@ -1,0 +1,60 @@
+package rkt
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/astaxie/beego/config"
+)
+
+var (
+	Domains  string
+	UserName string
+	RktImage string
+	PushCmd  string
+	FetchCmd string
+)
+
+func TestGetDockerConf(t *testing.T) {
+	path := "../testsuite.conf"
+	conf, err := config.NewConfig("ini", path)
+	if err != nil {
+		t.Errorf("Read %s error: %v", path, err.Error())
+	}
+
+	if domains := conf.String("test::domains"); domains != "" {
+		Domains = domains
+	} else {
+		t.Errorf("Read %s error: nil", domains)
+	}
+
+	if username := conf.String("test::username"); username != "" {
+		UserName = username
+	} else {
+		t.Errorf("Read %s error: nil", username)
+	}
+
+	if image := conf.String("test::image"); image != "" {
+		RktImage = image
+	} else {
+		t.Errorf("Read %s error: nil", image)
+	}
+
+	if pushCmd := conf.String("test::pushcmd"); pushCmd != "" {
+		PushCmd = pushCmd
+	} else {
+		PushCmd = "acpush"
+	}
+
+	if fetchCmd := conf.String("test::fetchcmd"); fetchCmd != "" {
+		FetchCmd = fetchCmd
+	} else {
+		FetchCmd = "rkt"
+	}
+}
+
+func ParseCmdCtx(cmd *exec.Cmd) (output string, err error) {
+	out, err := cmd.CombinedOutput()
+	output = string(out)
+	return output, err
+}

--- a/test/rkt/rkt_test.go
+++ b/test/rkt/rkt_test.go
@@ -1,0 +1,72 @@
+package rkt
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPullInit(t *testing.T) {
+	if err := checkTestingEnv(); err != nil {
+		t.Fatalf("Failed to prepare the testing enviornment: %v", err)
+	}
+
+	if err := pushImage(); err != nil {
+		//	t.Fatalf("Failed to push the testing image to Dockyard: %v", err)
+	}
+
+	if err := fetchImage(); err != nil {
+		t.Fatalf("Failed to fetch the testing image fro Dockyard: %v", err)
+	}
+}
+
+func pushImage() error {
+	imageName := strings.TrimSuffix(filepath.Base(RktImage), ".aci")
+	cmd := exec.Command(PushCmd, RktImage, RktImage+".asc", Domains+"/"+UserName+"/"+imageName)
+	if out, err := ParseCmdCtx(cmd); err != nil {
+		fmt.Println(out)
+		return err
+	}
+	return nil
+}
+
+func fetchImage() error {
+	tempDir, err := ioutil.TempDir("", "rkt-test-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	imageName := strings.TrimSuffix(filepath.Base(RktImage), ".aci")
+	cmd := exec.Command(FetchCmd, "fetch", Domains+"/"+UserName+"/"+imageName, "--dir="+tempDir)
+	fmt.Println(cmd)
+	if out, err := ParseCmdCtx(cmd); err != nil {
+		fmt.Println(out)
+		return err
+	}
+	return nil
+}
+
+func checkTestingEnv() error {
+	if _, err := exec.LookPath(FetchCmd); err != nil {
+		return err
+	}
+
+	if _, err := exec.LookPath(PushCmd); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(RktImage); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(RktImage + ".asc"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/testsuite.conf
+++ b/test/testsuite.conf
@@ -3,3 +3,6 @@
 domains  = containerops.me
 username = mabin
 client   = docker
+pushcmd  = acpush
+fetchcmd = rkt
+image    = 


### PR DESCRIPTION
Using acpush/rkt to test AppC 'pull/push' on Dockyard.

Since the rkt image needs to have user signature, the test won't create the testing image automatically.
'Readme.md' is a document for test user to setup the testing envoirnment.


Signed-off-by: liangchenye <liangchenye@huawei.com>