### PR TITLE
add more operations to dockyard updater client

### DIFF
--- a/updater/client/Makefile
+++ b/updater/client/Makefile
@@ -16,8 +16,12 @@ install: man
 	install -d -m 755 $(PREFIX)/share/bash-completion/completions
 	install -m 644 completions/bash/duc $(PREFIX)/share/bash-completion/completions
 
+uninstall:
+	rm -f $(PREFIX)/share/man/man1/duc.1 $(PREFIX)/share/bash-completion/completions/duc
 clean:
 	rm -f duc duc.1
+
+
 
 .PHONY: test .gofmt .govet .golint
 

--- a/updater/client/README.md
+++ b/updater/client/README.md
@@ -19,50 +19,78 @@ The Update Framework (TUF) helps developers to secure new or existing software u
 - install or run an appliance
 
 ## How to use it
-- dyclient init
+```
+	$ make install
+	$ man duc
+	$ duc help
+	NAME:
+	   duc - Dockyard Updater client
 
-  Create a default "~/.dyclient/config.json" if it is not exist.
+	USAGE:
+	   duc [global options] command [command options] [arguments...]
+
+	VERSION:
+	   0.0.1
+
+	COMMANDS:
+	    init        initiate default setting
+	    add         add a repository url
+	    remove      remove a repository url
+	    list        list the saved repositories or appliances of a certain repository
+
+	GLOBAL OPTIONS:
+	   --help, -h           show help
+	   --version, -v        print the version
+```
+
+### Command lines
+- duc init
+
+  Create a default "~/.dockyard/config.json" if it is not exist.
   This is used for a user to set his/her own configurations, see [Config](#config) for details.
-  Do not have to 'dyclient init' if all default settings are already suitable.
-- dyclient add "[repoURL](#repo-url)"
+  Do not have to 'duc init' if all default settings are already suitable.
+- duc add "[repoURL](#repo-url)"
 
   Add the repo url to the local update list, for example:
   ```
-	$ dyclient add app://localhost:8080/v1/dliang/dockyard
-	"app://localhost:8080/v1/dliang/dockyard" is added to repo list.
-	$ dyclient add app://localhost:8080/v1/dliang/dockyard
-	"app://localhost:8080/v1/dliang/dockyard" is already exist in repo list.
+	$ duc add app://localhost:8080/v1/official/dockyard
+	"app://localhost:8080/v1/official/dockyard" is added to repo list.
+	$ duc add app://localhost:8080/v1/official/dockyard
+	"app://localhost:8080/v1/official/dockyard" is already exist in repo list.
   ```
-- dyclient remove "repoURL"
+- duc remove "repoURL"
 
   Remove the `repo url` from the local update list, for example:
   ```
-	$ dyclient remove app://localhost:8080/v1/dliang/dockyard
-	"app://localhost:8080/v1/dliang/dockyard" is removed from repo list.
+	$ duc remove app://localhost:8080/v1/official/dockyard
+	"app://localhost:8080/v1/official/dockyard" is removed from repo list.
   ```
-- dyclient update "repoURL"
+- duc update "repoURL"
 
   Refresh the `repo`. If "repoURL" is not set, refresh all the local update repo list. For example:
     ```
-	$ dyclient update app://localhost:8080/v1/dliang/dockyard
-	start to refresh "app://localhost:8080/v1/dliang/dockyard"
+	$ duc update app://localhost:8080/v1/official/dockyard
+	start to refresh "app://localhost:8080/v1/official/dockyard"
 	1 new appliances found.
   ```
-- dyclient list "repoURL"
+- duc list "repoURL"
   
   List all the avaliable appliances inside this repo, for example:
   ```
-	$ dyclient list app://localhost:8080/v1/dliang/dockyard
-	centos/x86/dyclient.rpm
+	$ duc list
+	app://localhost:8080
+	app://containerops.me
+	$ duc list app://containerops.me/v1/official/dockyard
+	centos/x86/duc.rpm
   ```
-- dyclient pull --protocal "protocal:version" --server "localhost:8080" --path "localDir" "repoULR"
+- duc pull --protocal "protocal:version" --server "localhost:8080" --path "localDir" "repoULR"
   
   Fetch a certain appliance to [local cache directory](#cache-directory) if "localDir" is not set.
-  No need to set '--server' if 'DefaultServer' is set in ~/.dyclient/config.json.
-- dyclient push --protocal "protocal:version" --server "localhost:8080" --path "localDir" "repoURL"
+  No need to set '--server' if 'DefaultServer' is set in ~/.dockyard/config.json.
+- duc push --protocal "protocal:version" --server "localhost:8080" --path "localDir" "repoURL"
  
   Upload a certain appliance from from local cache directory if "localDir" is not set.
-  No need to set '--server' if 'DefaultServer' is set in ~/.dyclient/config.json.
+  No need to set '--server' if 'DefaultServer' is set in ~/.dockyard/config.json.
 
 ### Protocal
   The supported protocal will be `docker/appc/app/image`, now only support `app` (software packages).
@@ -73,12 +101,12 @@ The Update Framework (TUF) helps developers to secure new or existing software u
 ### ApplianceURL
   Differed with different protocals.
   
-  To the `app` protocal, it will be something like 'app://localhost:8080/v1/dliang/dockyard/centos/x86/dyclient.rpm'.
+  To the `app` protocal, it will be something like 'app://containerops.me/v1/official/dockyard/centos/x86/duc.rpm'.
 
 ### Repo URL
   Syntax of repo url should be [:protocal](#protocal)://url:port/[:version](#version)/[:namespace/:repository](#namespace-and-repository)
   ```
-	app://localhost:8080/v1/dliang/dockyard
+	app://containerops.me/v1/official/dockyard
 
   ```
 
@@ -87,16 +115,17 @@ Namespace and repository is the same concept in routers.
 To a docker user, he/she might pull an image like `library/alpine`,
 `library` is the namespace and `alpine` is the repository.
 
-To an app store user, he/she might pull a software like `dliang/dockyard/centos/x86/dyclient.rpm`,
-`dliang` is the namespace, `dockyard` is the repository.
+To an app store user, he/she might pull a software like `official/dockyard/centos/x86/duc.rpm`,
+`official` is the namespace, `dockyard` is the repository.
 
 ### Config
 ```
-   type dyclientConfig struct {
+   type ducConfig struct {
        DefaultServer string
        CacheDir string
+       Repos []string
    }
 ```
 
 ### Cache directory
-The default location is '~/.dyclient/Cache', can be reset in '~/.dyclient/config.json'.
+The default location is '~/.dockyard/Cache', can be reset in '~/.dockyard/config.json'.

--- a/updater/client/command.go
+++ b/updater/client/command.go
@@ -34,3 +34,48 @@ var initCommand = cli.Command{
 		}
 	},
 }
+
+var addCommand = cli.Command{
+	Name:  "add",
+	Usage: "add a repository url",
+
+	Action: func(context *cli.Context) {
+		var duc dyUpdaterConfig
+		url := context.Args().Get(0)
+		if err := duc.Add(url); err == nil {
+			fmt.Printf("Success in adding %s.\n", url)
+		} else {
+			fmt.Println(err)
+		}
+	},
+}
+
+var removeCommand = cli.Command{
+	Name:  "remove",
+	Usage: "remove a repository url",
+
+	Action: func(context *cli.Context) {
+		var duc dyUpdaterConfig
+		url := context.Args().Get(0)
+		if err := duc.Remove(url); err == nil {
+			fmt.Printf("Success in removing %s.\n", url)
+		} else {
+			fmt.Println(err)
+		}
+	},
+}
+
+var listCommand = cli.Command{
+	Name:  "list",
+	Usage: "list the saved repositories or appliances of a certain repository",
+
+	Action: func(context *cli.Context) {
+		var duc dyUpdaterConfig
+		if err := duc.Load(); err != nil {
+			fmt.Println(err)
+		}
+		for _, repo := range duc.Repos {
+			fmt.Println(repo)
+		}
+	},
+}

--- a/updater/client/completions/bash/duc
+++ b/updater/client/completions/bash/duc
@@ -142,6 +142,9 @@ _duc() {
 
 	local commands=(
 		init
+		add
+		remove
+		list
 	)
 
 	# These options are valid as global options for all client commands

--- a/updater/client/main.go
+++ b/updater/client/main.go
@@ -31,6 +31,9 @@ func main() {
 
 	app.Commands = []cli.Command{
 		initCommand,
+		addCommand,
+		removeCommand,
+		listCommand,
 	}
 
 	app.Run(os.Args)

--- a/updater/client/man/duc.1.md
+++ b/updater/client/man/duc.1.md
@@ -22,7 +22,17 @@ duc is the "Dockyard Updater Client" working with Dockyard Server.
 
 # COMMANDS
 **init**
-  Initiate "~/.dockyard/config.ini" with the default settings.
+  Initiate "~/.dockyard/config.json" with the default settings.
+
+**add**
+  Add a repository url
+
+**remove**
+  Remove a repository url
+  
+**list**
+  List the saved repositories or appliances of a certain repository
+
 
 # HISTORY
 July 2016, Originally compiled by Liang Chenye (liangchenye at huawei dot com)

--- a/updater/client/testdata/home/.dockyard/config.ini
+++ b/updater/client/testdata/home/.dockyard/config.ini
@@ -1,3 +1,0 @@
-DefaultServer=ductest.com
-CacheDir=/tmp/justtest/cache
-

--- a/updater/client/testdata/home/.dockyard/config.json
+++ b/updater/client/testdata/home/.dockyard/config.json
@@ -1,0 +1,5 @@
+{
+	"DefaultServer": "containerops.me",
+	"CacheDir": "/tmp/containeropsCache"
+}
+


### PR DESCRIPTION
1. change invalid urls in tests and docs to containerops.me 
2. add more operations to client

And start to work on a updater server next. 

@genedna  PTAL

Signed-off-by: liang chenye <liangchenye@huawei.com>