### PR TITLE
implement appv1 in client; c/s integration test succeed

### DIFF
--- a/updater/client/utils/config.go
+++ b/updater/client/utils/config.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	ErrorsDUCConfigExist  = errors.New("dockyard update client configuration is already exist")
-	ErrorsDUCInvalidRepo  = errors.New("invalid repository url")
+	ErrorsDUCEmptyURL     = errors.New("invalid repository url")
 	ErrorsDUCRepoExist    = errors.New("repository is already exist")
 	ErrorsDUCRepoNotExist = errors.New("repository is not exist")
 )
@@ -109,17 +109,9 @@ func (dyc *DyUpdaterClientConfig) Load() error {
 	return nil
 }
 
-func IsValidRepoURL(url string) bool {
-	if url == "" {
-		return false
-	}
-
-	return true
-}
-
 func (dyc *DyUpdaterClientConfig) Add(url string) error {
-	if !IsValidRepoURL(url) {
-		return ErrorsDUCInvalidRepo
+	if url == "" {
+		return ErrorsDUCEmptyURL
 	}
 
 	var err error
@@ -143,8 +135,8 @@ func (dyc *DyUpdaterClientConfig) Add(url string) error {
 }
 
 func (dyc *DyUpdaterClientConfig) Remove(url string) error {
-	if !IsValidRepoURL(url) {
-		return ErrorsDUCInvalidRepo
+	if url == "" {
+		return ErrorsDUCEmptyURL
 	}
 
 	if !dyc.exist() {

--- a/updater/client/utils/config_test.go
+++ b/updater/client/utils/config_test.go
@@ -74,7 +74,7 @@ func TestAddRemoveConfig(t *testing.T) {
 
 	// 'add'
 	err := conf.Add(invalidURL)
-	assert.Equal(t, err, ErrorsDUCInvalidRepo)
+	assert.Equal(t, err, ErrorsDUCEmptyURL)
 	err = conf.Add(validURL)
 	assert.Nil(t, err, "Failed to add repository")
 	err = conf.Add(validURL)

--- a/updater/client/utils/repo.go
+++ b/updater/client/utils/repo.go
@@ -26,7 +26,11 @@ type DyUpdaterClientRepo interface {
 	Supported(url string) bool
 	New(url string) (DyUpdaterClientRepo, error)
 	List() ([]string, error)
-	Get() error
+	GetFile(name string) ([]byte, error)
+	GetPublicKey() ([]byte, error)
+	GetMeta() ([]byte, error)
+	GetMetaSign() ([]byte, error)
+	Put(name string, content []byte) error
 	String() string
 }
 

--- a/updater/client/utils/repo/appV1/appV1_test.go
+++ b/updater/client/utils/repo/appV1/appV1_test.go
@@ -16,27 +16,99 @@ limitations under the License.
 package appV1
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	duc_utils "github.com/containerops/dockyard/updater/client/utils"
+	dus_utils "github.com/containerops/dockyard/updater/server/utils"
 )
+
+func getTestURL() string {
+	// Start a dus server and set the enviornment like this:
+	//     $ export DUS_TEST_SERVER=appV1://localhost:1234
+	server := os.Getenv("DUS_TEST_SERVER")
+	if server == "" {
+		return ""
+	}
+
+	return server + "/namespaceonlyfortest/repoonlyfortest"
+}
 
 // TestInitConfig tests the Init function
 func TestInitConfig(t *testing.T) {
 	var appV1 DyUpdaterClientAppV1Repo
 
-	validURL := "appV1://containerops.me/containerops/offical"
-	f, err := appV1.New(validURL)
-	assert.Nil(t, err, "Fail to setup a valid repo")
-	assert.Equal(t, f.String(), validURL, "Fail to parse url")
-
-	invalidURL := "appInvalid://containerops.me/containerops/offical"
-	_, err = appV1.New(invalidURL)
+	invalidURL := "appInvalid://containerops.me/containerops/official"
+	_, err := appV1.New(invalidURL)
 	assert.Equal(t, err, duc_utils.ErrorsDURRepoInvalid, "Fail to parse invalid url")
 
 	invalidURL2 := "appV1://containerops.me/containerops"
 	_, err = appV1.New(invalidURL2)
 	assert.Equal(t, err, duc_utils.ErrorsDURRepoInvalid, "Fail to parse invalid url")
+
+	validURL := "appV1://containerops.me/containerops/official"
+	f, err := appV1.New(validURL)
+	assert.Nil(t, err, "Fail to setup a valid repo")
+	assert.Equal(t, appV1.generateURL(), "http://"+"containerops.me/app/v1/containerops/official", "Fail to compose a url")
+	assert.Equal(t, f.String(), validURL, "Fail to parse url")
+
+}
+
+// TestOper tests add/get/getmeta/getmetasign/list
+func TestOper(t *testing.T) {
+	var appV1 DyUpdaterClientAppV1Repo
+
+	validURL := getTestURL()
+
+	// Skip the test if the testing enviornment is not ready
+	if validURL == "" {
+		fmt.Printf("Skip the '%s' test since the testing enviornment is not ready.\n", "List")
+		return
+	}
+
+	f, _ := appV1.New(validURL)
+
+	// Init the data and also test the put function
+	_, path, _, _ := runtime.Caller(0)
+	for _, n := range []string{"appA", "appB"} {
+		file := filepath.Join(filepath.Dir(path), "testdata", n)
+		content, _ := ioutil.ReadFile(file)
+		err := f.Put(n, content)
+		assert.Nil(t, err, "Fail to put file")
+	}
+
+	// Test list
+	l, err := f.List()
+	assert.Nil(t, err, "Fail to list")
+	assert.Equal(t, len(l), 2, "Fail to list or something wrong in put")
+	ok := (l[0] == "appA" && l[1] == "appB") || (l[0] == "appB" && l[1] == "appA")
+	assert.Equal(t, true, ok, "Fail to list the correct data")
+
+	// Test get file
+	fileBytes, err := f.GetFile("appA")
+	assert.Nil(t, err, "Fail to get file")
+	expectedBytes, _ := ioutil.ReadFile(filepath.Join(filepath.Dir(path), "testdata", "appA"))
+	assert.Equal(t, fileBytes, expectedBytes, "Fail to get the correct data")
+
+	// Test get meta
+	metaBytes, err := f.GetMeta()
+	assert.Nil(t, err, "Fail to get meta file")
+
+	// Test get metasign
+	signBytes, err := f.GetMetaSign()
+	assert.Nil(t, err, "Fail to get meta signature file")
+
+	// Test get public key
+	pubkeyBytes, err := f.GetPublicKey()
+	assert.Nil(t, err, "Fail to get public key file")
+
+	// VIP: Verify meta/sign with public to make real sure that everything works perfect
+	err = dus_utils.SHA256Verify(pubkeyBytes, metaBytes, signBytes)
+	assert.Nil(t, err, "Fail to verify the meta data")
 }

--- a/updater/client/utils/repo/appV1/testdata/appA
+++ b/updater/client/utils/repo/appV1/testdata/appA
@@ -1,0 +1,1 @@
+this is appA.

--- a/updater/client/utils/repo/appV1/testdata/appB
+++ b/updater/client/utils/repo/appV1/testdata/appB
@@ -1,0 +1,1 @@
+this is appB.

--- a/updater/duf_test.sh
+++ b/updater/duf_test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+echo "start test, killing the exist 'dus' server"
+pidof dus | xargs kill -9
+
+TMPDIR=$(mktemp -d)
+TMPSTORAGE=${TMPDIR}/storage
+TMPKM=${TMPDIR}/km
+echo "creating tmp storage dir: " $TMPSTORAGE
+mkdir -p $TMPSTORAGE
+echo "creating tmp keymanager dir: " $TMPKM
+mkdir -p $TMPKM
+
+
+echo "start to compile server"
+cd server
+make
+
+echo "start the updater server"
+./dus web --storage "local:/""$TMPSTORAGE" --keymanager "local:/""$TMPKM"  &
+
+echo "start to compile client"
+cd ../client
+make
+cd ..
+
+echo "set enviornment and start to run tests"
+export DUS_TEST_SERVER="appV1://localhost:1234"
+go test -v $(go list ./... | grep -v /vendor/)
+
+echo "killing the testing 'dus' server"
+killall dus
+
+echo "clean all the generated data"
+rm -fr $TMPDIR
+
+echo "end of test"

--- a/updater/server/handler/appV1.go
+++ b/updater/server/handler/appV1.go
@@ -60,6 +60,20 @@ func AppListFileV1Handler(ctx *macaron.Context) (int, []byte) {
 	return httpRet("AppV1 List files", apps, err)
 }
 
+// Get the public key of the namespace/repository
+func AppGetPublicKeyV1Handler(ctx *macaron.Context) (int, []byte) {
+	namespace := ctx.Params(":namespace")
+	repository := ctx.Params(":repository")
+
+	appV1, _ := utils.NewDUSProtocal("appV1")
+	data, err := appV1.GetPublicKey(namespace + "/" + repository)
+	if err == nil {
+		return http.StatusOK, data
+	} else {
+		return httpRet("AppV1 Get Public Key", nil, err)
+	}
+}
+
 // Get the meta data of all the namespace/repository
 func AppGetMetaV1Handler(ctx *macaron.Context) (int, []byte) {
 	namespace := ctx.Params(":namespace")

--- a/updater/server/router.go
+++ b/updater/server/router.go
@@ -33,6 +33,8 @@ func SetRouters(m *macaron.Macaron) {
 			m.Group("/:namespace/:repository", func() {
 				// List files
 				m.Get("/", h.AppListFileV1Handler)
+				// Get pub key of the whole repo
+				m.Get("/pubkey", h.AppGetPublicKeyV1Handler)
 				// Get meta data of the whole repo
 				m.Get("/meta", h.AppGetMetaV1Handler)
 				// Get meta signature data of the whole repo

--- a/updater/server/utils/key.go
+++ b/updater/server/utils/key.go
@@ -58,52 +58,47 @@ func GenerateRSAKeyPair(bits int) ([]byte, []byte, error) {
 	return pem.EncodeToMemory(privBlock), pem.EncodeToMemory(pubBlock), nil
 }
 
-func RSAEncrypt(path string, contentByte []byte) ([]byte, error) {
-	pubKey, err := getPubKey(path)
+func RSAEncrypt(keyBytes []byte, contentBytes []byte) ([]byte, error) {
+	pubKey, err := getPubKey(keyBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	return rsa.EncryptPKCS1v15(rand.Reader, pubKey, contentByte)
+	return rsa.EncryptPKCS1v15(rand.Reader, pubKey, contentBytes)
 }
 
-func RSADecrypt(path string, contentByte []byte) ([]byte, error) {
-	privKey, err := getPrivKey(path)
+func RSADecrypt(keyBytes []byte, contentBytes []byte) ([]byte, error) {
+	privKey, err := getPrivKey(keyBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	return rsa.DecryptPKCS1v15(rand.Reader, privKey, contentByte)
+	return rsa.DecryptPKCS1v15(rand.Reader, privKey, contentBytes)
 }
 
-func SHA256Sign(path string, contentByte []byte) ([]byte, error) {
-	privKey, err := getPrivKey(path)
+func SHA256Sign(keyBytes []byte, contentBytes []byte) ([]byte, error) {
+	privKey, err := getPrivKey(keyBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	hashed := sha256.Sum256(contentByte)
+	hashed := sha256.Sum256(contentBytes)
 	return rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA256, hashed[:])
 }
 
-func SHA256Verify(path string, contentByte []byte, signByte []byte) error {
-	pubKey, err := getPubKey(path)
+func SHA256Verify(keyBytes []byte, contentBytes []byte, signBytes []byte) error {
+	pubKey, err := getPubKey(keyBytes)
 	if err != nil {
 		return err
 	}
 
-	signStr := hex.EncodeToString(signByte)
-	newSignByte, _ := hex.DecodeString(signStr)
-	hashed := sha256.Sum256(contentByte)
-	return rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], newSignByte)
+	signStr := hex.EncodeToString(signBytes)
+	newSignBytes, _ := hex.DecodeString(signStr)
+	hashed := sha256.Sum256(contentBytes)
+	return rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], newSignBytes)
 }
 
-func getPrivKey(path string) (*rsa.PrivateKey, error) {
-	privBytes, err := readBytes(path)
-	if err != nil {
-		return nil, err
-	}
-
+func getPrivKey(privBytes []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(privBytes)
 	if block == nil {
 		return nil, errors.New("Fail to decode private key")
@@ -112,12 +107,7 @@ func getPrivKey(path string) (*rsa.PrivateKey, error) {
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
 
-func getPubKey(path string) (*rsa.PublicKey, error) {
-	pubBytes, err := readBytes(path)
-	if err != nil {
-		return nil, err
-	}
-
+func getPubKey(pubBytes []byte) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode(pubBytes)
 	if block == nil {
 		return nil, errors.New("Fail to decode public key")

--- a/updater/server/utils/key_test.go
+++ b/updater/server/utils/key_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 package utils
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -29,22 +27,10 @@ func TestRSAGenerateEnDe(t *testing.T) {
 	privBytes, pubBytes, err := GenerateRSAKeyPair(1024)
 	assert.Nil(t, err, "Fail to genereate RSA Key Pair")
 
-	tmpPath, err := ioutil.TempDir("", "dus-test-")
-	defer os.RemoveAll(tmpPath)
-	assert.Nil(t, err, "Fail to create temp dir")
-
-	privFile := filepath.Join(tmpPath, "rsa_private_key.pem")
-	err = ioutil.WriteFile(privFile, privBytes, 0644)
-	assert.Nil(t, err, "Fail to write private key file")
-
-	pubFile := filepath.Join(tmpPath, "rsa_public_key.pem")
-	err = ioutil.WriteFile(pubFile, pubBytes, 0644)
-	assert.Nil(t, err, "Fail to write public key file")
-
 	testData := []byte("This is the testdata for encrypt and decryp")
-	encrypted, err := RSAEncrypt(pubFile, testData)
+	encrypted, err := RSAEncrypt(pubBytes, testData)
 	assert.Nil(t, err, "Fail to encrypt data")
-	decrypted, err := RSADecrypt(privFile, encrypted)
+	decrypted, err := RSADecrypt(privBytes, encrypted)
 	assert.Nil(t, err, "Fail to decrypt data")
 	assert.Equal(t, testData, decrypted, "Fail to get correct data after en/de")
 }
@@ -58,11 +44,12 @@ func TestSHA256Sign(t *testing.T) {
 	testContentFile := filepath.Join(dir, "hello.txt")
 	testSignFile := filepath.Join(dir, "hello.sig")
 
-	signByte, _ := readBytes(testSignFile)
-	contentByte, _ := readBytes(testContentFile)
-	testByte, err := SHA256Sign(testPrivFile, contentByte)
+	privBytes, _ := readBytes(testPrivFile)
+	signBytes, _ := readBytes(testSignFile)
+	contentBytes, _ := readBytes(testContentFile)
+	testBytes, err := SHA256Sign(privBytes, contentBytes)
 	assert.Nil(t, err, "Fail to sign")
-	assert.Equal(t, testByte, signByte, "Fail to get valid sign data ")
+	assert.Equal(t, testBytes, signBytes, "Fail to get valid sign data ")
 }
 
 // TestSHA256Verify
@@ -74,10 +61,11 @@ func TestSHA256Verify(t *testing.T) {
 	testContentFile := filepath.Join(dir, "hello.txt")
 	testSignFile := filepath.Join(dir, "hello.sig")
 
-	signByte, _ := readBytes(testSignFile)
-	contentByte, _ := readBytes(testContentFile)
-	err := SHA256Verify(testPubFile, contentByte, signByte)
+	pubBytes, _ := readBytes(testPubFile)
+	signBytes, _ := readBytes(testSignFile)
+	contentBytes, _ := readBytes(testContentFile)
+	err := SHA256Verify(pubBytes, contentBytes, signBytes)
 	assert.Nil(t, err, "Fail to verify valid signed data")
-	err = SHA256Verify(testPubFile, []byte("Invalid content data"), signByte)
+	err = SHA256Verify(pubBytes, []byte("Invalid content data"), signBytes)
 	assert.NotNil(t, err, "Fail to verify invalid signed data")
 }

--- a/updater/server/utils/km/local/local.go
+++ b/updater/server/utils/km/local/local.go
@@ -121,5 +121,6 @@ func (dkml *DyKeyManagerLocal) Sign(key string, data []byte) ([]byte, error) {
 		}
 	}
 
-	return dus_utils.SHA256Sign(filepath.Join(keyDir, defaultPrivateKey), data)
+	privBytes, _ := ioutil.ReadFile(filepath.Join(keyDir, defaultPrivateKey))
+	return dus_utils.SHA256Sign(privBytes, data)
 }

--- a/updater/server/utils/protocal.go
+++ b/updater/server/utils/protocal.go
@@ -26,6 +26,7 @@ type DyUpdaterServerProtocal interface {
 	Supported(protocal string) bool
 	New(protocal string) (DyUpdaterServerProtocal, error)
 	List(key string) ([]string, error)
+	GetPublicKey(key string) ([]byte, error)
 	GetMeta(key string) ([]byte, error)
 	GetMetaSign(key string) ([]byte, error)
 	Get(key string) ([]byte, error)

--- a/updater/server/utils/protocal/appV1/appV1.go
+++ b/updater/server/utils/protocal/appV1/appV1.go
@@ -70,6 +70,15 @@ func (ap *DyUpdaterServerAppV1) List(key string) ([]string, error) {
 	return s.List(key)
 }
 
+func (ap *DyUpdaterServerAppV1) GetPublicKey(key string) ([]byte, error) {
+	s, err := dus_utils.NewDUSStorage("")
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetPublicKey(key)
+}
+
 func (ap *DyUpdaterServerAppV1) GetMeta(key string) ([]byte, error) {
 	s, err := dus_utils.NewDUSStorage("")
 	if err != nil {

--- a/updater/server/utils/setting.go
+++ b/updater/server/utils/setting.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2016 The ContainerOps Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	dusSettingsLock sync.Mutex
+	dusSettings     = make(map[string]string)
+)
+
+func SetSetting(key string, value string) error {
+	if key == "" {
+		return errors.New("setting key should not be empty")
+	}
+
+	dusSettingsLock.Lock()
+	defer dusSettingsLock.Unlock()
+
+	dusSettings[key] = value
+	return nil
+}
+
+func GetSetting(key string) (string, error) {
+	if key == "" {
+		return "", errors.New("setting key should not be empty")
+	}
+
+	if v, ok := dusSettings[key]; ok {
+		return v, nil
+	} else {
+		return "", errors.New("setting key is not exist")
+	}
+}

--- a/updater/server/utils/setting_test.go
+++ b/updater/server/utils/setting_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 The ContainerOps Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetting
+func TestSetting(t *testing.T) {
+	err := SetSetting("", "content")
+	assert.NotNil(t, err, "Fail to set wrong setting")
+
+	err = SetSetting("a", "content")
+	assert.Nil(t, err, "Fail to set correct setting")
+
+	err = SetSetting("a", "new content")
+	assert.Nil(t, err, "Fail to set correct setting")
+
+	_, err = GetSetting("")
+	assert.NotNil(t, err, "Fail to get empty key")
+
+	_, err = GetSetting("b")
+	assert.NotNil(t, err, "Fail to get non exist key")
+
+	v, err := GetSetting("a")
+	assert.Nil(t, err, "Fail to get exist key")
+	assert.Equal(t, v, "new content", "Fail to get correct value")
+}


### PR DESCRIPTION
- appV1 operations are all implemented in client side
- the server and client integration test works good.
   The test is done by testcases and a `duf_test.sh` file

TODO:
- finish the command line of client side 
- more docs
- merge to dockyard 
 
Signed-off-by: liang chenye <liangchenye@huawei.com>